### PR TITLE
Naming playlists

### DIFF
--- a/rfid/lib/rfid/handler.ex
+++ b/rfid/lib/rfid/handler.ex
@@ -24,10 +24,8 @@ defmodule RFID.Handler do
   end
 
   defp extract_tag_id(playlist) do
-    ~r/\A(?<tag_id>\d+)/
-    |> Regex.named_captures(playlist)
-    |> case do
-      %{"tag_id" => tag_id} -> tag_id
+    case Musicbox.Player.playlist_information(playlist) do
+      %{"id" => id} -> id
       _ -> nil
     end
   end

--- a/ui/assets/css/theme.scss
+++ b/ui/assets/css/theme.scss
@@ -30,11 +30,6 @@ section.player {
   padding-bottom: 10px;
 }
 
-form button,
-a.button {
-  margin-top: 20px;
-}
-
-table button.is-small {
-  padding-top: .2em;
+table {
+  width: 100%;
 }

--- a/ui/lib/musicbox/player.ex
+++ b/ui/lib/musicbox/player.ex
@@ -225,6 +225,7 @@ defmodule Musicbox.Player do
 
       %{
         id: id,
+        name: maybe_display_name(id),
         song_count: Enum.count(songs),
         duration: duration,
         songs: get_playlist_songs(id)
@@ -254,7 +255,7 @@ defmodule Musicbox.Player do
       {:ok, song_list} = MpdClient.Playlists.list(item["playlist"])
       Enum.member?(song_list, path)
     end)
-    |> Enum.map(fn playlist -> playlist["playlist"] end)
+    |> Enum.map(fn playlist -> maybe_display_name(playlist["playlist"]) end)
   end
 
   defp set_playlist_name(id, name) do
@@ -276,5 +277,19 @@ defmodule Musicbox.Player do
 
   defp new_playlist_name(id, name) do
     "#" <> id <> " - " <> name
+  end
+
+  defp maybe_display_name(name) do
+    case String.starts_with?(name, "#") do
+      true -> extract_playlist_name(name)
+      _ -> name
+    end
+  end
+
+  defp extract_playlist_name(name) do
+    case Regex.run(~r/(?<= - ).*$/, name) do
+      [h] -> h
+      _ -> name
+    end
   end
 end

--- a/ui/lib/musicbox/player.ex
+++ b/ui/lib/musicbox/player.ex
@@ -124,7 +124,7 @@ defmodule Musicbox.Player do
     {old_name, new_name} = set_playlist_name(id, name)
 
     MpdClient.Playlists.rename(old_name, new_name)
-    {:reply, playlist_name, state}
+    {:reply, new_name, state}
   end
 
   def handle_call({:current_volume}, _from, state) do

--- a/ui/lib/musicbox/player.ex
+++ b/ui/lib/musicbox/player.ex
@@ -121,7 +121,7 @@ defmodule Musicbox.Player do
   end
 
   def handle_call({:rename_playlist, %{"id" => id, "name" => name}}, _from, state) do
-    {id, playlist_name} = new_playlist_name(id, name)
+    {id, playlist_name} = set_playlist_name(id, name)
 
     MpdClient.Playlists.rename(id, playlist_name)
     {:reply, playlist_name, state}
@@ -257,7 +257,7 @@ defmodule Musicbox.Player do
     |> Enum.map(fn playlist -> playlist["playlist"] end)
   end
 
-  defp new_playlist_name(id, name) do
+  defp set_playlist_name(id, name) do
     new_name = case String.starts_with?(id, "#") do
       true -> rename_changed_playlist(id, name)
       false -> new_playlist_name(id, name)

--- a/ui/lib/musicbox_web/live/playlists_live.ex
+++ b/ui/lib/musicbox_web/live/playlists_live.ex
@@ -35,16 +35,16 @@ defmodule MusicboxWeb.PlaylistsLive do
                     <input name="id" type="hidden" value="<%= playlist.id %>">
                     <div class="field has-addons">
                       <div class="control">
-                        <input name="name" autocomplete="off" class="input" />
+                        <input name="name" autocomplete="off" class="input" placeholder="<%= playlist.name %>" />
                       </div>
                       <div class="control">
-                        <button class="button" type="submit">Rename playlist</button>
+                        <button class="button" type="submit">Update name</button>
                       </div>
                     </div>
                   </form>
                 <% else %>
                   <button phx-click="edit_playlist_name" value="<%= playlist.id %>" class="button">
-                    <%= playlist.id %>
+                    <%= playlist.name %>
                   </button>
                 <% end %>
               </td>

--- a/ui/lib/musicbox_web/live/playlists_live.ex
+++ b/ui/lib/musicbox_web/live/playlists_live.ex
@@ -32,6 +32,13 @@ defmodule MusicboxWeb.PlaylistsLive do
               <td><%= playlist.id %></td>
               <td><%= playlist.song_count %></td>
               <td><%= duration playlist.duration %></td>
+              <td>
+                <form phx-submit="set_playlist_name">
+                  <input name="id" type="hidden" value="<%= playlist.id %>">
+                  <input name="name" autocomplete="off"/>
+                  <button type="submit">Submit</button>
+                </form>
+              </td>
             </tr>
           <% end %>
         </table>
@@ -59,6 +66,11 @@ defmodule MusicboxWeb.PlaylistsLive do
   def handle_event("play_playlist", playlist, socket) do
     Logger.debug("Playing playlist #{playlist}")
     Player.play_playlist(playlist)
+    {:noreply, socket}
+  end
+
+  def handle_event("set_playlist_name", playlist, socket) do
+    Player.rename_playlist(playlist)
     {:noreply, socket}
   end
 

--- a/ui/lib/musicbox_web/live/songs_live.ex
+++ b/ui/lib/musicbox_web/live/songs_live.ex
@@ -43,7 +43,7 @@ defmodule MusicboxWeb.SongsLive do
                   <select name="playlist" id="playlist">
                     <option value="" selected>-- Select a Playlist --</option>
                     <%= for playlist <- @playlists do %>
-                      <option value="<%= playlist.id %>"><%= playlist.id %></option>
+                      <option value="<%= playlist.id %>"><%= playlist.name %></option>
                     <% end %>
                   </select>
                 </form>

--- a/ui/lib/musicbox_web/templates/song/new.html.eex
+++ b/ui/lib/musicbox_web/templates/song/new.html.eex
@@ -6,7 +6,8 @@
     <%= file_input f, :file, multiple: true, accept: ".mp3" %>
   </div>
 
-  <div>
+  <!-- lols until we change something here -->
+  <div style="margin-top: 20px;">
     <%= submit "Submit", class: "button is-primary" %>
   </div>
 <% end %>


### PR DESCRIPTION
Some ugly string manipulation to name and rename playlists with Paracusia. It misses a commit for reading the card id (that obviously does not change when renaming the playlist). I'll add that as well as some styling for this 😬

With some extra key value storage we could probably just add a name to the playlist, without changing the id of the .m3u file and therefore not breaking the cards. If you have some thoughts on that, let me know :)