### PR TITLE
Automatically use HTTP or ALSA

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,20 @@ This application is Dockerized. With Docker and docker-compose installed:
 
 ```shell
 docker-compose build
-docker-compose run --rm app mix deps.get
 ```
 
 ### Start development environment
 
+On Linux we can mount `/dev/snd` in the Docker container and mpd can directly
+use our host system's sound output.
+
+macOS doesn't have `/dev/snd` or ALSA, so we configure mpd to output via an HTTP/Shoutcast
+server. Then on our macOS host we can use iTunes or VLC to connect to the stream.
+
+Use `start_env.sh` to automatically pick the correct configuration.
+
 ```shell
-docker-compose up
+./start_env.sh
 ```
 
 Put any music files you want into `mpd/music` and they'll be detected automatically by mpd.

--- a/docker-compose.alsa.yml
+++ b/docker-compose.alsa.yml
@@ -1,0 +1,7 @@
+version: "3.6"
+
+services:
+  mpd:
+    command: "mpd --no-daemon --stdout /mpd/conf/mpd.conf"
+    devices:
+      - "/dev/snd:/dev/snd"

--- a/docker-compose.http.yml
+++ b/docker-compose.http.yml
@@ -1,0 +1,7 @@
+version: "3.6"
+
+services:
+  mpd:
+    command: "mpd --no-daemon --stdout /mpd/conf/mpd.http.conf"
+    ports:
+      - "8060:8000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,11 +4,6 @@ services:
   mpd:
     build:
       context: mpd
-    devices:
-      - "/dev/snd:/dev/snd"
-    ports:
-      - "6600:6600"
-      - "8060:8000"
     volumes:
       - ./mpd/music:/mpd/music
       - ./mpd/conf:/mpd/conf

--- a/mpd/conf/mpd.http.conf
+++ b/mpd/conf/mpd.http.conf
@@ -19,6 +19,13 @@ replaygain           "auto"
 volume_normalization "yes"
 
 audio_output {
-  type    "alsa"
-  name    "ALSA Default Device"
+  type              "httpd"
+  name              "Local HTTP Server"
+  encoder           "wave"
+  port              "8000"
+  bind_to_address   "0.0.0.0"
+  # quality           "5.0"
+  # bitrate           "128"
+  format            "44100:16:1"
+  max_clients       "0"
 }

--- a/start_dev.sh
+++ b/start_dev.sh
@@ -18,4 +18,4 @@ elif [[ $output == "http" ]]; then
 fi
 echo "-------------------------------------------------------------------------"
 
-docker-compose -f docker-compose.yml -f docker-compose.${output}.conf up
+docker-compose -f docker-compose.yml -f docker-compose.${output}.yml up

--- a/start_dev.sh
+++ b/start_dev.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+output="http"
+
+[ -e /dev/snd ] && output="alsa"
+
+echo "-------------------------------------------------------------------------"
+if [[ $output == "alsa" ]]; then
+  echo "mpd is being started in ALSA output mode."
+  echo "Sound will be output via the host system's sound card"
+elif [[ $output == "http" ]]; then
+  echo "mpd is being started in HTTP/Shoutcast output mode"
+  echo "You can listen to the output by connecting to the HTTP stream:"
+  echo
+  echo "http://localhost:8060" # check docker-compose.http.conf for the port
+  echo
+  echo "Warning: Volume control does not work when using HTTP output!"
+fi
+echo "-------------------------------------------------------------------------"
+
+docker-compose -f docker-compose.yml -f docker-compose.${output}.conf up


### PR DESCRIPTION
This is one solution to the issue of development on macOS. I don't like having to install anything on the host system as it defeats the convenience of having dockerized apps and versioned configuration.

The solution here is when `/dev/snd` isn't available, use HTTP/Shoutcast output. I've added a `start_dev.sh` script to automatically pick the correct strategy and apply the right configuration for mpd and docker.

I haven't tested this yet on Linux but will before merging.